### PR TITLE
Convert test tags to strings

### DIFF
--- a/lib/shindo.rb
+++ b/lib/shindo.rb
@@ -53,7 +53,7 @@ module Shindo
     def tests(description, tags = [], &block)
       return self if Thread.main[:exit] || Thread.current[:reload]
 
-      tags = [*tags]
+      tags = [*tags].collect { |tag| tag.to_s }
       @tag_stack.push(tags)
       @befores.push([])
       @afters.push([])


### PR DESCRIPTION
- This is all that can be matched on the command line, so if symbols/integers are used to tag the test, convert them to strings when attempting to match passed in tags.
