### PR TITLE
Remove ruby's warning 

### DIFF
--- a/lib/shindo.rb
+++ b/lib/shindo.rb
@@ -33,6 +33,7 @@ module Shindo
           @unless_tagged << tag[1..-1]
         end
       end
+      @pending = nil
       Formatador.display_line
       tests(description, tags, &block)
     end


### PR DESCRIPTION
Example to reproduce on MRI 1.9.3
-  `$VERBOSE = true`
- with `-w` option
