### PR TITLE
Capture any type of exception in a 'raises' block

### DIFF
--- a/lib/shindo.rb
+++ b/lib/shindo.rb
@@ -131,7 +131,7 @@ module Shindo
               instance_eval(&block)
             rescue Shindo::Pending
               @pending = true
-            rescue => error
+            rescue Exception => error
               error
             end
             [value, value.is_a?(expectation)]


### PR DESCRIPTION
The current way of handling the exceptions in a raises block only
captures exceptions inheriting StandardError which is the default
for rescue IIRC.

Not sure if this is intended behaviour though. This patch changes it
so that **all** the exceptions are rescued by the block.

Code example exhibiting current behaviour:

```
class MyException < Exception; end

# raises block will not rescue MyException breaking tests
#
raises MyException, 'something happened' do
  raises MyException.new
end
```
