### PR TITLE
Fix Kernel.trap setup for sigint by going from a lambda to a Proc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,8 @@ matrix:
     - rvm: rbx
 
 rvm:
-  - 1.8.7
-  - 1.9.2
-  - 1.9.3
   - 2.0.0
+  - 2.3.1
   - jruby
   - rbx
   - ree

--- a/lib/shindo/bin.rb
+++ b/lib/shindo/bin.rb
@@ -1,6 +1,6 @@
 require File.join(File.dirname(__FILE__), '..', 'shindo')
 
-@interrupt = lambda do
+@interrupt = proc do
   unless Thread.main[:exit]
     Formatador.display_line('Gracefully Exiting... (ctrl-c to force)')
     Thread.main[:exit] = true

--- a/shindo.gemspec
+++ b/shindo.gemspec
@@ -53,7 +53,13 @@ Gem::Specification.new do |s|
   ## List your development dependencies here. Development dependencies are
   ## those that are only needed during development
   # s.add_development_dependency('DEVDEPNAME', [">= 1.1.0", "< 2.0.0"])
-  s.add_development_dependency('rake')
+  
+  if RUBY_VERSION.to_f <= 1.8
+    s.add_development_dependency('rake', '~> 10.5')
+  else
+    s.add_development_dependency('rake')
+  end
+
   s.add_development_dependency('rdoc')
 
   ## Leave this section as-is. It will be automatically generated from the

--- a/tests/bin_tests.rb
+++ b/tests/bin_tests.rb
@@ -43,5 +43,4 @@ Shindo.tests('bin') do
 
     tests('$?.exitstatus').returns(1) { $?.exitstatus }
   end
-
 end

--- a/tests/data/sigint
+++ b/tests/data/sigint
@@ -1,0 +1,4 @@
+Shindo.tests do
+  test('success') { true }
+  sleep(20)
+end

--- a/tests/tests_helper.rb
+++ b/tests/tests_helper.rb
@@ -1,4 +1,5 @@
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib', 'shindo'))
+require 'open3'
 
 BIN = File.join(File.dirname(__FILE__), '..', 'bin', 'shindo')
 


### PR DESCRIPTION
 It should be noted that a better test can be put in place, but figured I do that in another PR. 
Specifically, we probably want send the process a ctrl-c sequence by writing to stdin, and verifying we get our warning, etc. But maybe that should be part of this PR as well. Wasn't sure how hacky the test would be, might have to use expect. 

 - Switched out the block passed to Kernel.trap for SIGINT from a lambda
to proc. The block given to Kernel.trap gets a signal argument. Not
expecting this argument in a lambda caused a runtime error and prevented graceful exiting
- Added a few test units using popen3 to make sure the process gets
  sucessfully killed when a sigint is sent
- Add a test helper spawn_bin to crank up shindo in a monitorable way
  via Open3::popen3
- Add bin_is_alive? Helper to check an arbitrary pid