### PR TITLE
Properly report test suite results without error.

### DIFF
--- a/lib/shindo/bin.rb
+++ b/lib/shindo/bin.rb
@@ -74,11 +74,11 @@ run_in_thread(helpers, tests, @thread_locals.merge({:tags => tags}))
 @totals   ||= { :failed => 0, :errored => 0, :pending => 0, :succeeded => 0 }
 @success  = @totals[:failed] + @totals[:errored] == 0
 status = []
-status << "[red]#{@totals[:failed]} failed[/]," if @totals[:failed] > 0
-status << "[red]#{@totals[:errored]} errored[/]," if @totals[:errored] > 0
-status << "[yellow]#{@totals[:pending]} pending[/]," if @totals[:pending] > 0
+status << "[red]#{@totals[:failed]} failed[/]" if @totals[:failed] > 0
+status << "[red]#{@totals[:errored]} errored[/]" if @totals[:errored] > 0
+status << "[yellow]#{@totals[:pending]} pending[/]" if @totals[:pending] > 0
 status << "[green]#{@totals[:succeeded]} succeeded[/]"
-status = status[0...-2].join(', ') << ' and ' << status[-1] if status.length > 3
+status = [status[0...-1].join(', '), 'and', status[-1]] if status.length >= 2
 status << "in [bold]#{Time.now - @started_at}[/] seconds"
 Formatador.display_lines(['', status.join(' '), ''])
 

--- a/tests/bin_tests.rb
+++ b/tests/bin_tests.rb
@@ -30,16 +30,16 @@ Shindo.tests('bin') do
 
   tests('error') do
     @output = bin(path('error'))
-    includes('ok + returns true')             { @output }
-    includes('1 errored, 1 succeeded')        { @output }
+    includes('ok + returns true')                   { @output }
+    includes('1 errored and 1 succeeded')           { @output }
 
     tests('$?.exitstatus').returns(1) { $?.exitstatus }
   end
 
   tests('contained-error') do
     @output = bin(path('contained-error'))
-    includes('ok + returns true')             { @output }
-    includes('1 failed, 1 errored, 1 succeeded')        { @output }
+    includes('ok + returns true')                   { @output }
+    includes('1 failed, 1 errored and 1 succeeded') { @output }
 
     tests('$?.exitstatus').returns(1) { $?.exitstatus }
   end


### PR DESCRIPTION
This fixes errors such as:

~~~
/usr/share/gems/gems/shindo-0.3.9/lib/shindo/bin.rb:83:in `<top (required)>': undefined method `join' for "[red]1 failed[/],, [red]1 errored[/], and [green]662 succeeded[/]in [bold]11.777175132830932[/] seconds":String (NoMethodError)
	from /usr/share/gems/gems/shindo-0.3.9/bin/shindo:5:in `require_relative'
	from /usr/share/gems/gems/shindo-0.3.9/bin/shindo:5:in `<top (required)>'
	from /usr/bin/shindo:23:in `load'
	from /usr/bin/shindo:23:in `<main>'
~~~

The line adding fancy `,` and `and` was not never exercised until the status was not extended by `errored` field in b56710f. This brings it to life and improves the formatting from:

~~~
1 failed, 1 errored, 3 pending, 955 succeeded in 15.626122789453369 seconds
~~~

to

~~~
1 failed, 1 errored, 3 pending and 955 succeeded in 15.758976896940673 seconds
~~~

The other option would be to just the delete the line.