### PR TITLE
Shindo::Rake: run with current Ruby interpreter

### DIFF
--- a/lib/shindo/rake.rb
+++ b/lib/shindo/rake.rb
@@ -7,7 +7,7 @@ module Shindo
     def initialize
       desc "Run shindo tests"
       task :tests do
-        system 'shindo'
+        ruby '-S', 'shindo'
         fail if $? != 0
       end
     end


### PR DESCRIPTION
It's possible to have multiple Ruby interpreters installed. For example
on Debian at the moment ww have ruby2.7 and ruby3.0, while we transition
from one to the other. We always want to run tests under the same Ruby
that is running rake itself.