### PR TITLE
Add Ruby 3.1 to CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.1', '2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', 'head', truffleruby-head]
+        ruby-version: ['2.1', '2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', 'head', truffleruby-head]
 
     steps:
     - uses: actions/checkout@v2.4.0

--- a/lib/shindo/bin.rb
+++ b/lib/shindo/bin.rb
@@ -29,7 +29,7 @@ for argument in ARGV
     if File.directory?(path)
       tests ||= []
       tests |= Dir.glob(File.join(path, '**', '*tests.rb'))
-    elsif File.exists?(path)
+    elsif File.exist?(path)
       tests ||= []
       tests << path
     else


### PR DESCRIPTION
Add Ruby 3.1 to CI.

This PR also includes replacing a `File.exists?` with `File.exist?` to get ruby-head green.